### PR TITLE
avoid namespace ambiguity

### DIFF
--- a/inc/MbedSerial.h
+++ b/inc/MbedSerial.h
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.
 #include "Serial.h"
 #include "ManagedString.h"
 
-namespace mb=mbed;
+namespace mb=::mbed;
 
 namespace codal
 {


### PR DESCRIPTION
I am getting a C++ compilation error because the ambiguity between ::mbed and codal::mbed.